### PR TITLE
Adds "parent" selector

### DIFF
--- a/development/uilang-1.0.1.js
+++ b/development/uilang-1.0.1.js
@@ -73,6 +73,9 @@ document.addEventListener("DOMContentLoaded", function() {
         case undefined:
           updateClass(e.target)
           break
+        case "parent" :
+          updateClass(e.target.parentNode)
+          break
         default:
           var target = document.querySelectorAll(self.targetSelector)
           var i = target.length


### PR DESCRIPTION
Adds a “parent” selector in addition to the existing “target” selector,
and causes the class update to effect the immediate parent of the
target element.
